### PR TITLE
Reset shadowcopylist at start of mountshadowcopy

### DIFF
--- a/autosnap.sh
+++ b/autosnap.sh
@@ -53,7 +53,7 @@ makesnapshot() {
 
 mountshadowcopy() {
 	share=$1
-
+	shadowcopylist=""
 	# GET ALL EXISTING SNAPSHOT ON RBD
 	snapcollection=$(rbd snap ls $rbdpool/$share | awk '{print $2}' | grep -- 'GMT-.*-autosnap$' | sort | sed 's/-autosnap$//g')
 


### PR DESCRIPTION
I added a second rbd and noticed my previous changes introduced a bug. The shadowcopylist variable was never reset, so the script attempted to mount all the snapshots timestamps found on previous images on the subsequent images, producing errors when run manually. Setting it to "" at the start of the function resolves the bug.
